### PR TITLE
Fixed misleading incomplete message in terminal

### DIFF
--- a/bin/3.1_T2Processing/getIncidenceSize.py
+++ b/bin/3.1_T2Processing/getIncidenceSize.py
@@ -198,7 +198,7 @@ if __name__ == "__main__":
     if len(glob.glob(inputFolder+'/*Stroke_mask.nii.gz')) > 0:
         incidenceMask = glob.glob(inputFolder+'/*Stroke_mask.nii.gz')[0]
     else:
-        sys.exit("Error: '%s' has no affected or masked regions." % (inputFolder,))
+        sys.exit("Notice: '%s' has no affected or masked regions." % (inputFolder,))
 
     path = os.path.join(inputFolder)
     regMR_list = findBETData(path)

--- a/bin/3.1_T2Processing/getIncidenceSize.py
+++ b/bin/3.1_T2Processing/getIncidenceSize.py
@@ -198,7 +198,7 @@ if __name__ == "__main__":
     if len(glob.glob(inputFolder+'/*Stroke_mask.nii.gz')) > 0:
         incidenceMask = glob.glob(inputFolder+'/*Stroke_mask.nii.gz')[0]
     else:
-        sys.exit("Notice: '%s' has no affected or masked regions." % (inputFolder,))
+        sys.exit("Error: '%s' has no affected or masked regions." % (inputFolder,))
 
     path = os.path.join(inputFolder)
     regMR_list = findBETData(path)

--- a/bin/3.1_T2Processing/getIncidenceSize_par.py
+++ b/bin/3.1_T2Processing/getIncidenceSize_par.py
@@ -238,7 +238,7 @@ if __name__ == "__main__":
     if len(glob.glob(inputFolder+'/*Stroke_mask.nii.gz')) > 0:
         incidenceMask = glob.glob(inputFolder+'/*Stroke_mask.nii.gz')[0]
     else:
-        sys.exit("Notice: '%s' has no affected or masked regions." % (inputFolder,))
+        sys.exit("Error: '%s' has no affected or masked regions." % (inputFolder,))
 
     path = os.path.join(inputFolder)
     regMR_list = findBETData(path)


### PR DESCRIPTION
If batchProc.py is executed and it doesn't find a stroke mask no 'incomplete' message will appear in the terminal anymore instead it will log that no mask was found for the subject and will show 'complete' in the terminal. The processing step will be skipped in that case. 
getIncidenceSize_par.py and getIncidenceSize.py were adjusted that it shows an error in the terminal if it doesn't find a mask.